### PR TITLE
Add host-based policy system with keyword evaluation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.27.1 h1:9W30zRlYrefrDV2JE2O8VDtJ1yPGownxciz5rrbQZis=

--- a/policy.go
+++ b/policy.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// HostClass represents the classification of a host.
+type HostClass int
+
+const (
+	HostAllow    HostClass = iota
+	HostDeny
+	HostGrey
+	HostUnlisted
+)
+
+func (h HostClass) String() string {
+	switch h {
+	case HostAllow:
+		return "allow"
+	case HostDeny:
+		return "deny"
+	case HostGrey:
+		return "grey"
+	case HostUnlisted:
+		return "unlisted"
+	default:
+		return "unknown"
+	}
+}
+
+// Action represents the proxy's decision for a request.
+type Action int
+
+const (
+	ActionAllow    Action = iota
+	ActionDeny
+	ActionEvaluate
+)
+
+func (a Action) String() string {
+	switch a {
+	case ActionAllow:
+		return "allow"
+	case ActionDeny:
+		return "deny"
+	case ActionEvaluate:
+		return "evaluate"
+	default:
+		return "unknown"
+	}
+}
+
+// Config holds the policy configuration loaded from YAML.
+type Config struct {
+	Policy   string   `yaml:"policy"`
+	Allow    []string `yaml:"allow"`
+	Deny     []string `yaml:"deny"`
+	Grey     []string `yaml:"grey"`
+	Keywords []string `yaml:"keywords"`
+
+	// Pre-built lookup maps (not serialized).
+	allowSet map[string]bool
+	denySet  map[string]bool
+	greySet  map[string]bool
+}
+
+// LoadConfig reads and parses a YAML policy file. Returns an error if the
+// file cannot be read or if the policy mode is invalid.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	switch cfg.Policy {
+	case "open", "lax", "strict":
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid policy mode: %q (must be open, lax, or strict)", cfg.Policy)
+	}
+
+	cfg.buildSets()
+	return &cfg, nil
+}
+
+// DefaultConfig returns an open-policy config with empty lists. This is used
+// when no config file is present, preserving backwards compatibility.
+func DefaultConfig() *Config {
+	cfg := &Config{Policy: "open"}
+	cfg.buildSets()
+	return cfg
+}
+
+func (c *Config) buildSets() {
+	c.allowSet = make(map[string]bool, len(c.Allow))
+	for _, h := range c.Allow {
+		c.allowSet[strings.ToLower(h)] = true
+	}
+	c.denySet = make(map[string]bool, len(c.Deny))
+	for _, h := range c.Deny {
+		c.denySet[strings.ToLower(h)] = true
+	}
+	c.greySet = make(map[string]bool, len(c.Grey))
+	for _, h := range c.Grey {
+		c.greySet[strings.ToLower(h)] = true
+	}
+}
+
+// stripPort returns the hostname portion of a host string, removing any port.
+func stripPort(host string) string {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		// No port present (or some other parse issue) — use as-is.
+		return host
+	}
+	return h
+}
+
+// Classify determines which list a host belongs to.
+func (c *Config) Classify(host string) HostClass {
+	h := strings.ToLower(stripPort(host))
+	if c.denySet[h] {
+		return HostDeny
+	}
+	if c.allowSet[h] {
+		return HostAllow
+	}
+	if c.greySet[h] {
+		return HostGrey
+	}
+	return HostUnlisted
+}
+
+// Decide applies the policy matrix to a host classification and returns the
+// resulting action.
+func (c *Config) Decide(class HostClass) Action {
+	switch class {
+	case HostAllow:
+		return ActionAllow
+	case HostDeny:
+		return ActionDeny
+	case HostGrey:
+		if c.Policy == "strict" {
+			return ActionDeny
+		}
+		return ActionEvaluate
+	case HostUnlisted:
+		switch c.Policy {
+		case "open":
+			return ActionAllow
+		case "lax":
+			return ActionEvaluate
+		case "strict":
+			return ActionDeny
+		}
+	}
+	return ActionDeny
+}
+
+// EvaluateResponse performs a case-insensitive keyword scan on the response
+// body. It returns (true, "") if no keywords match, or (false, keyword) with
+// the first matched keyword.
+func (c *Config) EvaluateResponse(body []byte) (bool, string) {
+	lower := bytes.ToLower(body)
+	for _, kw := range c.Keywords {
+		if bytes.Contains(lower, []byte(strings.ToLower(kw))) {
+			return false, kw
+		}
+	}
+	return true, ""
+}

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func testConfig() *Config {
+	cfg := &Config{
+		Policy:   "lax",
+		Allow:    []string{"api.openai.com", "api.anthropic.com"},
+		Deny:     []string{"malicious.example.com"},
+		Grey:     []string{"api.github.com"},
+		Keywords: []string{"password", "secret_key", "credential"},
+	}
+	cfg.buildSets()
+	return cfg
+}
+
+// --- Classify ---
+
+func TestClassify_AllowListed(t *testing.T) {
+	cfg := testConfig()
+	if got := cfg.Classify("api.openai.com"); got != HostAllow {
+		t.Errorf("expected HostAllow, got %v", got)
+	}
+}
+
+func TestClassify_AllowListedWithPort(t *testing.T) {
+	cfg := testConfig()
+	if got := cfg.Classify("api.openai.com:443"); got != HostAllow {
+		t.Errorf("expected HostAllow, got %v", got)
+	}
+}
+
+func TestClassify_DenyListed(t *testing.T) {
+	cfg := testConfig()
+	if got := cfg.Classify("malicious.example.com"); got != HostDeny {
+		t.Errorf("expected HostDeny, got %v", got)
+	}
+}
+
+func TestClassify_DenyListedWithPort(t *testing.T) {
+	cfg := testConfig()
+	if got := cfg.Classify("malicious.example.com:8080"); got != HostDeny {
+		t.Errorf("expected HostDeny, got %v", got)
+	}
+}
+
+func TestClassify_GreyListed(t *testing.T) {
+	cfg := testConfig()
+	if got := cfg.Classify("api.github.com"); got != HostGrey {
+		t.Errorf("expected HostGrey, got %v", got)
+	}
+}
+
+func TestClassify_Unlisted(t *testing.T) {
+	cfg := testConfig()
+	if got := cfg.Classify("unknown.example.com"); got != HostUnlisted {
+		t.Errorf("expected HostUnlisted, got %v", got)
+	}
+}
+
+func TestClassify_CaseInsensitive(t *testing.T) {
+	cfg := testConfig()
+	if got := cfg.Classify("API.OpenAI.COM"); got != HostAllow {
+		t.Errorf("expected HostAllow for uppercase host, got %v", got)
+	}
+}
+
+// --- Decide (full matrix) ---
+
+func TestDecide_Matrix(t *testing.T) {
+	tests := []struct {
+		policy string
+		class  HostClass
+		want   Action
+	}{
+		// open mode
+		{"open", HostAllow, ActionAllow},
+		{"open", HostDeny, ActionDeny},
+		{"open", HostGrey, ActionEvaluate},
+		{"open", HostUnlisted, ActionAllow},
+		// lax mode
+		{"lax", HostAllow, ActionAllow},
+		{"lax", HostDeny, ActionDeny},
+		{"lax", HostGrey, ActionEvaluate},
+		{"lax", HostUnlisted, ActionEvaluate},
+		// strict mode
+		{"strict", HostAllow, ActionAllow},
+		{"strict", HostDeny, ActionDeny},
+		{"strict", HostGrey, ActionDeny},
+		{"strict", HostUnlisted, ActionDeny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.policy+"_"+tt.class.String(), func(t *testing.T) {
+			cfg := &Config{Policy: tt.policy}
+			if got := cfg.Decide(tt.class); got != tt.want {
+				t.Errorf("Decide(%v) in %s mode = %v, want %v",
+					tt.class, tt.policy, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- EvaluateResponse ---
+
+func TestEvaluateResponse_Match(t *testing.T) {
+	cfg := testConfig()
+	passed, kw := cfg.EvaluateResponse([]byte(`{"token": "secret_key_abc123"}`))
+	if passed {
+		t.Error("expected evaluation to fail")
+	}
+	if kw != "secret_key" {
+		t.Errorf("expected matched keyword 'secret_key', got %q", kw)
+	}
+}
+
+func TestEvaluateResponse_CaseInsensitive(t *testing.T) {
+	cfg := testConfig()
+	passed, kw := cfg.EvaluateResponse([]byte(`Your PASSWORD is wrong`))
+	if passed {
+		t.Error("expected evaluation to fail for case-insensitive match")
+	}
+	if kw != "password" {
+		t.Errorf("expected matched keyword 'password', got %q", kw)
+	}
+}
+
+func TestEvaluateResponse_NoMatch(t *testing.T) {
+	cfg := testConfig()
+	passed, kw := cfg.EvaluateResponse([]byte(`{"status": "ok", "data": [1,2,3]}`))
+	if !passed {
+		t.Errorf("expected evaluation to pass, but matched %q", kw)
+	}
+}
+
+func TestEvaluateResponse_EmptyBody(t *testing.T) {
+	cfg := testConfig()
+	passed, _ := cfg.EvaluateResponse([]byte{})
+	if !passed {
+		t.Error("expected evaluation to pass on empty body")
+	}
+}
+
+func TestEvaluateResponse_NoKeywords(t *testing.T) {
+	cfg := &Config{Keywords: nil}
+	cfg.buildSets()
+	passed, _ := cfg.EvaluateResponse([]byte("password secret_key credential"))
+	if !passed {
+		t.Error("expected evaluation to pass when no keywords configured")
+	}
+}
+
+// --- LoadConfig ---
+
+func TestLoadConfig_Valid(t *testing.T) {
+	content := `
+policy: strict
+allow:
+  - api.openai.com
+deny:
+  - evil.com
+grey:
+  - api.github.com
+keywords:
+  - password
+`
+	path := filepath.Join(t.TempDir(), "policy.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if cfg.Policy != "strict" {
+		t.Errorf("expected policy 'strict', got %q", cfg.Policy)
+	}
+	if len(cfg.Allow) != 1 || cfg.Allow[0] != "api.openai.com" {
+		t.Errorf("unexpected allow list: %v", cfg.Allow)
+	}
+	if len(cfg.Keywords) != 1 || cfg.Keywords[0] != "password" {
+		t.Errorf("unexpected keywords: %v", cfg.Keywords)
+	}
+	// Verify sets are built
+	if cfg.Classify("api.openai.com") != HostAllow {
+		t.Error("expected classify to work after LoadConfig")
+	}
+}
+
+func TestLoadConfig_InvalidPolicy(t *testing.T) {
+	content := `policy: yolo`
+	path := filepath.Join(t.TempDir(), "policy.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid policy mode")
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/policy.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Policy != "open" {
+		t.Errorf("expected default policy 'open', got %q", cfg.Policy)
+	}
+	// Unlisted hosts should be allowed in open mode
+	if cfg.Decide(cfg.Classify("anything.com")) != ActionAllow {
+		t.Error("expected unlisted host to be allowed in open mode")
+	}
+}


### PR DESCRIPTION
Implement allow/deny/grey host lists with three policy modes (open, lax, strict). Grey-listed and unlisted hosts (depending on mode) get post-hoc keyword scanning — the request goes through but the response is blocked if it contains flagged keywords. Backwards compatible: no config file defaults to open mode.